### PR TITLE
Fix `likelihood` and add it to CI (by ignoring `calibration-cdl.h5` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           cd TimepixAnalysis
           nim c buildTpa
-          ./buildTpa
+          # set `IN_CI=true` to ignore the `calibration-cdl.h5` file's existence
+          IN_CI=true ./buildTpa --compileLikelihood
 
 #      - name: Run tests
 #        shell: bash

--- a/Analysis/ingrid/likelihood.nim
+++ b/Analysis/ingrid/likelihood.nim
@@ -29,9 +29,11 @@ else:
 const compileDate = CompileDate & " at " & CompileTime
 const versionStr = "Version: $# built on: $#" % [commitHash, compileDate]
 
+
+const IgnoreCdlFile {.booldefine.} = false
 const h5cdl_file = currentSourcePath() / "../../../resources/calibration-cdl.h5"
 const cdlExists = fileExists(h5cdl_file)
-when not cdlExists:
+when not cdlExists and not IgnoreCdlFile:
   {.fatal: "CAST CDL reference file `calibration-cdl.h5` does not exist at: " &
     $h5cdl_file.}
 

--- a/Analysis/ingrid/likelihood.nim
+++ b/Analysis/ingrid/likelihood.nim
@@ -678,7 +678,7 @@ proc buildSeptemEvents(ctx: LikelihoodContext, septemDf: DataFrame,
       ## it here!
       result[0].add septemFrame
       result[1].add (pixels: septemFrame.pixels, eventNumber: evNum.int,
-                     toa: newSeq[uint16](), toaCombined: newSeq[uint64]())
+                     toa: newSeq[uint16](), toaCombined: newSeq[uint64](), ftoa: newSeq[uint8]())
 
 proc reconstructSeptemEvents(ctx: LikelihoodContext, septemEvents: seq[RecoInputEvent[PixInt]],
                              runNumber: int): seq[RecoEvent[PixInt]] =
@@ -970,7 +970,7 @@ proc applySeptemVeto(h5f: var H5File,
         ## XXX: for full ToA support in Timepix3, need to also read the `toa` data and insert
         ## it here!
         let inp = (pixels: septemFrame.pixels, eventNumber: evNum.int,
-                   toa: newSeq[uint16](), toaCombined: newSeq[uint64]())
+                   toa: newSeq[uint16](), toaCombined: newSeq[uint64](), ftoa: newSeq[uint8]())
         let recoEv = recoEvent(inp, -1,
                                runNumber, searchRadius = ctx.vetoCfg.searchRadius,
                                dbscanEpsilon = ctx.vetoCfg.dbscanEpsilon,


### PR DESCRIPTION
We now allow to ignore the `calibration-cdl.h5` file, if the `-d:IgnoreCdlFile=true` compile time argument is given. It's still better to verify the user has access to the file for the time being, unless they know what they are doing.

In the build tool, we now compile `likelihood` if the `--compileLikelihood` argument is given and ignore the CDL file if the `IN_CI=true` environment variable is set.